### PR TITLE
Fix creating InitgPty element

### DIFF
--- a/SepaWriter/SepaCreditTransfer.cs
+++ b/SepaWriter/SepaCreditTransfer.cs
@@ -87,7 +87,7 @@ namespace Perrich.SepaWriter
             grpHdr.NewElement("CtrlSum", StringUtils.FormatAmount(headerControlSum));
             grpHdr.NewElement("InitgPty").NewElement("Nm", InitiatingPartyName);
             if (InitiatingPartyId != null)
-                grpHdr.NewElement("InitgPty").NewElement("Id", InitiatingPartyId);
+                XmlUtils.GetFirstElement(xml, "CstmrDrctDbtInitn//InitgPty").NewElement("Id", InitiatingPartyId);
 
             // Part 2: Payment Information
             var pmtInf = XmlUtils.GetFirstElement(xml, "CstmrCdtTrfInitn").NewElement("PmtInf");

--- a/SepaWriter/SepaDebitTransfer.cs
+++ b/SepaWriter/SepaDebitTransfer.cs
@@ -94,7 +94,7 @@ namespace Perrich.SepaWriter
             grpHdr.NewElement("CtrlSum", StringUtils.FormatAmount(headerControlSum));
             grpHdr.NewElement("InitgPty").NewElement("Nm", InitiatingPartyName);
             if (InitiatingPartyId != null)
-                grpHdr.NewElement("InitgPty").NewElement("Id", InitiatingPartyId);
+                XmlUtils.GetFirstElement(xml, "CstmrDrctDbtInitn//InitgPty").NewElement("Id", InitiatingPartyId);
 
             // Part 2: Payment Information for each Sequence Type.
             foreach (SepaSequenceType seqTp in Enum.GetValues(typeof(SepaSequenceType)))


### PR DESCRIPTION
InitgPty is duplicated if you use InitiatingPartyName and InitiatingPartyId in the same document.