### PR TITLE
Added optional address class and xml. Removed InitiatingPartyName as mandatory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 .sonar
 /TestResults
+/packages

--- a/SepaWriter/SepaCreditTransfer.cs
+++ b/SepaWriter/SepaCreditTransfer.cs
@@ -98,13 +98,22 @@ namespace Perrich.SepaWriter
             grpHdr.NewElement("CreDtTm", StringUtils.FormatDateTime(CreationDate));
             grpHdr.NewElement("NbOfTxs", numberOfTransactions);
             grpHdr.NewElement("CtrlSum", StringUtils.FormatAmount(headerControlSum));
-            grpHdr.NewElement("InitgPty").NewElement("Nm", InitiatingPartyName);
-			
-			if (InitiatingPartyId != null) {
-				XmlUtils.GetFirstElement(grpHdr, "InitgPty").
-					NewElement("Id").NewElement("OrgId").
-					NewElement("Othr").NewElement("Id", InitiatingPartyId);
-			}
+            if (!String.IsNullOrEmpty(InitiatingPartyName) || InitiatingPartyId != null)
+            {
+                var initgPty = grpHdr.NewElement("InitgPty");
+
+                if (!String.IsNullOrEmpty(InitiatingPartyName))
+                {
+                    initgPty.NewElement("Nm", InitiatingPartyName);
+                }
+
+                if (InitiatingPartyId != null)
+                {
+                    initgPty.
+                        NewElement("Id").NewElement("OrgId").
+                        NewElement("Othr").NewElement("Id", InitiatingPartyId);
+                }
+            }
 
             // Part 2: Payment Information
             var pmtInf = XmlUtils.GetFirstElement(xml, "CstmrCdtTrfInitn").NewElement("PmtInf");
@@ -133,18 +142,25 @@ namespace Perrich.SepaWriter
 			
 			pmtInf.NewElement("ReqdExctnDt", StringUtils.FormatDate(RequestedExecutionDate));
             pmtInf.NewElement("Dbtr").NewElement("Nm", Debtor.Name);
+            if (Debtor.Address != null)
+            {
+                AddPostalAddressElements(pmtInf, "Dbtr", Debtor.Address);
+            }
 			if (InitiatingPartyId != null) {
 				XmlUtils.GetFirstElement(pmtInf, "Dbtr").
 					NewElement("Id").NewElement("OrgId").
 					NewElement("Othr").NewElement("Id", InitiatingPartyId);
 			}
 
-
             var dbtrAcct = pmtInf.NewElement("DbtrAcct");
             dbtrAcct.NewElement("Id").NewElement("IBAN", Debtor.Iban);
             dbtrAcct.NewElement("Ccy", DebtorAccountCurrency);
 
             pmtInf.NewElement("DbtrAgt").NewElement("FinInstnId").NewElement("BIC", Debtor.Bic);
+            if (Debtor.AgentAddress != null)
+            {
+                AddPostalAddressElements(pmtInf, "FinInstnId", Debtor.AgentAddress);
+            }
 
             if (IsInternational)
             {
@@ -180,6 +196,10 @@ namespace Perrich.SepaWriter
                        .SetAttribute("Ccy", transfer.Currency);
             XmlUtils.CreateBic(cdtTrfTxInf.NewElement("CdtrAgt"), transfer.Creditor);
             cdtTrfTxInf.NewElement("Cdtr").NewElement("Nm", transfer.Creditor.Name);
+            if (transfer.Creditor.Address != null)
+            {
+                AddPostalAddressElements(pmtInf, "Cdtr", transfer.Creditor.Address);
+            }
 
             cdtTrfTxInf.NewElement("CdtrAcct").NewElement("Id").NewElement("IBAN", transfer.Creditor.Iban);
 

--- a/SepaWriter/SepaIbanData.cs
+++ b/SepaWriter/SepaIbanData.cs
@@ -12,10 +12,12 @@ namespace Perrich.SepaWriter
         private string bic;
         private string iban;
         private string name;
+        private SepaPostalAddress address;
+        private SepaPostalAddress agentAddress;
         private bool withoutBic;
 
         // Regex to find space
-        private static readonly Regex SpaceRegex = new Regex("\\s+", RegexOptions.Compiled); 
+        private static readonly Regex SpaceRegex = new Regex("\\s+", RegexOptions.Compiled);
 
         /// <summary>
         /// The Name of the owner
@@ -26,6 +28,28 @@ namespace Perrich.SepaWriter
             set
             {
                 name = StringUtils.GetLimitedString(value, 70);
+            }
+        }
+
+        public SepaPostalAddress Address
+        {
+            get { return address; }
+            set
+            {
+                if (!value.IsValid)
+                    throw new SepaRuleException("Iban Address data is invalid.");
+                address = value;
+            }
+        }
+
+        public SepaPostalAddress AgentAddress
+        {
+            get { return agentAddress; }
+            set
+            {
+                if (!value.IsValid)
+                    throw new SepaRuleException("Iban Address data is invalid.");
+                agentAddress = value;
             }
         }
 
@@ -86,5 +110,15 @@ namespace Perrich.SepaWriter
         {
             return MemberwiseClone();
         }
+    }
+
+    public enum PostalAddressType
+    {
+        ADDR,
+        PBOX,
+        HOME,
+        BIZZ,
+        MLTO,
+        DLVY
     }
 }

--- a/SepaWriter/SepaPostalAddress.cs
+++ b/SepaWriter/SepaPostalAddress.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Remoting.Messaging;
+
+namespace Perrich.SepaWriter
+{
+    public class SepaPostalAddress
+    {
+        private string dept;
+        private string subDept;
+        private string strtNm;
+        private string bldgNb;
+        private string pstCd;
+        private string twnNm;
+        private string ctrySubDvsn;
+        private string ctry;
+        private List<string> adrLine;
+
+        public PostalAddressType? AddressType { get; set; }
+
+        public string Dept 
+        { 
+            get { return dept; }
+            set 
+            { 
+                if (value != null && value.Length > 70)
+                    throw new SepaRuleException(string.Format("Invalid length of Dept \"{0}\", must be less than or equal to 70 characters.", value));
+
+                dept = value;
+
+            }
+        }
+        public string SubDept
+        { 
+            get { return subDept; }
+            set 
+            { 
+                if (value != null && value.Length > 70)
+                    throw new SepaRuleException(string.Format("Invalid length of SubDept \"{0}\", must be less than or equal to 70 characters.", value));
+
+                subDept = value;
+            }
+        }
+        public string StrtNm
+        { 
+            get { return strtNm; }
+            set 
+            { 
+                if (value != null && value.Length > 70)
+                    throw new SepaRuleException(string.Format("Invalid length of StrtNm \"{0}\", must be less than or equal to 70 characters.", value));
+
+                strtNm = value;
+            }
+        }
+        public string BldgNb
+        { 
+            get { return bldgNb; }
+            set 
+            { 
+                if (value != null && value.Length > 16)
+                    throw new SepaRuleException(string.Format("Invalid length of BldgNb \"{0}\", must be less than or equal to 16 characters.", value));
+
+                bldgNb = value;
+            }
+        }
+        public string PstCd
+        { 
+            get { return pstCd; }
+            set 
+            { 
+                if (value != null && value.Length > 16)
+                    throw new SepaRuleException(string.Format("Invalid length of PstCd \"{0}\", must be less than or equal to 16 characters.", value));
+
+                pstCd = value;
+            }
+        }
+        public string TwnNm
+        { 
+            get { return twnNm; }
+            set 
+            { 
+                if (value != null && value.Length > 35)
+                    throw new SepaRuleException(string.Format("Invalid length of TwnNm \"{0}\", must be less than or equal to 35 characters.", value));
+
+                twnNm = value;
+            }
+        }
+        public string CtrySubDvsn
+        { 
+            get { return ctrySubDvsn; }
+            set 
+            { 
+                if (value != null && value.Length > 35)
+                    throw new SepaRuleException(string.Format("Invalid length of CtrySubDvsn \"{0}\", must be less than or equal to 35 characters.", value));
+
+                ctrySubDvsn = value;
+            }
+        }
+        public string Ctry
+        { 
+            get { return ctry; }
+            set 
+            { 
+                if (value != null && value.Length != 2)
+                    throw new SepaRuleException(string.Format("Invalid length of Ctry \"{0}\", must be less a 2 character ISO country code.", value));
+
+                ctry = value.ToUpper();
+            }
+        }
+        public List<String> AdrLine
+        { 
+            get { return adrLine; }
+            set 
+            {
+                if (value != null)
+                    foreach (var line in value)
+                        if (line == null || line.Length > 70)
+                            throw new SepaRuleException(string.Format("AdrLine cannot contain null items or an item has an invalid length of \"{0}\", must be less than or equal to 70 characters.", line));
+
+                if (value != null && value.Count > 7)
+                    throw new SepaRuleException(string.Format("AdrLine cannot contain more than 7 items, contains \"{0}\".", value.Count));
+
+                adrLine = value;
+            }
+        }
+
+        public bool IsValid 
+        {
+            get
+            {
+                return (String.IsNullOrEmpty(Dept) || Dept.Length <= 70) &&
+                       (String.IsNullOrEmpty(SubDept) || SubDept.Length <= 70) &&
+                       (String.IsNullOrEmpty(StrtNm) || StrtNm.Length <= 70) &&
+                       (String.IsNullOrEmpty(BldgNb) || BldgNb.Length <= 16) &&
+                       (String.IsNullOrEmpty(PstCd) || PstCd.Length <= 16) &&
+                       (String.IsNullOrEmpty(TwnNm) || TwnNm.Length <= 35) &&
+                       (String.IsNullOrEmpty(CtrySubDvsn) || CtrySubDvsn.Length <= 35) &&
+                       (String.IsNullOrEmpty(Ctry) || Ctry.Length == 2) &&
+                       (AdrLine == null || AdrLine.All(x => x.Length <= 70));
+            }
+        }
+    }
+}

--- a/SepaWriter/SepaTransfer.cs
+++ b/SepaWriter/SepaTransfer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Xml;
+using Perrich.SepaWriter.Utils;
 
 namespace Perrich.SepaWriter
 {
@@ -151,6 +152,32 @@ namespace Perrich.SepaWriter
                 throw new SepaRuleException("End to End Id '" + endToEndId + "' must be unique in a transfer.");
             }
         }
+        
+        protected void AddPostalAddressElements(XmlElement pmtInf, string existingElementKey, SepaPostalAddress address)
+        {
+            var pstlAdr = XmlUtils.GetFirstElement(pmtInf, existingElementKey).NewElement("PstlAdr");
+            if (address.AddressType.HasValue)
+                pstlAdr.NewElement("AdrTp", address.AddressType.ToString());
+            if (!String.IsNullOrEmpty(address.Dept))
+                pstlAdr.NewElement("Dept", address.Dept);
+            if (!String.IsNullOrEmpty(address.SubDept))
+                pstlAdr.NewElement("SubDept", address.SubDept);
+            if (!String.IsNullOrEmpty(address.StrtNm))
+                pstlAdr.NewElement("StrtNm", address.StrtNm);
+            if (!String.IsNullOrEmpty(address.BldgNb))
+                pstlAdr.NewElement("BldgNb", address.BldgNb);
+            if (!String.IsNullOrEmpty(address.PstCd))
+                pstlAdr.NewElement("PstCd", address.PstCd);
+            if (!String.IsNullOrEmpty(address.TwnNm))
+                pstlAdr.NewElement("TwnNm", address.TwnNm);
+            if (!String.IsNullOrEmpty(address.CtrySubDvsn))
+                pstlAdr.NewElement("CtrySubDvsn", address.CtrySubDvsn);
+            if (!String.IsNullOrEmpty(address.Ctry))
+                pstlAdr.NewElement("Ctry", address.Ctry);
+            if (address.AdrLine != null)
+                foreach (var line in address.AdrLine)
+                    pstlAdr.NewElement("AdrLine", line);
+        }
 
         /// <summary>
         ///     Is Mandatory data are set ? In other case a SepaRuleException will be thrown
@@ -166,10 +193,10 @@ namespace Perrich.SepaWriter
             {
                 throw new SepaRuleException("The message identification is mandatory.");
             }
-            if (string.IsNullOrEmpty(InitiatingPartyName))
-            {
-                throw new SepaRuleException("The initial party name is mandatory.");
-            }
+            //if (string.IsNullOrEmpty(InitiatingPartyName))
+            //{
+            //    throw new SepaRuleException("The initial party name is mandatory.");
+            //}
         }
 
         /// <summary>

--- a/SepaWriter/SepaTransfer.cs
+++ b/SepaWriter/SepaTransfer.cs
@@ -193,10 +193,6 @@ namespace Perrich.SepaWriter
             {
                 throw new SepaRuleException("The message identification is mandatory.");
             }
-            //if (string.IsNullOrEmpty(InitiatingPartyName))
-            //{
-            //    throw new SepaRuleException("The initial party name is mandatory.");
-            //}
         }
 
         /// <summary>

--- a/SepaWriter/SepaWriter.csproj
+++ b/SepaWriter/SepaWriter.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="SepaChargeBearer.cs" />
     <Compile Include="SepaInstructionForCreditor.cs" />
+    <Compile Include="SepaPostalAddress.cs" />
     <Compile Include="SepaSchema.cs" />
     <Compile Include="Constant.cs" />
     <Compile Include="SepaSequenceType.cs" />


### PR DESCRIPTION
- InitiatingPartyName does not appear to be mandatory data according to the schema, removed this from the validation check.
- Make "InitiatingPartyName" optional when not included. 
- Introduced "PstlAdr" class. 
- Introduced XML conversion for "PstlAdr" in GenerateXml output. 
- Added helper method for "PstlAdr" class XML. 
- Added optional address elements to SepaIbanData.