### PR TITLE
Refactored the "AddPostalAddressElements" method into XmlUtils. Updat…

### DIFF
--- a/SepaWriter/SepaCreditTransfer.cs
+++ b/SepaWriter/SepaCreditTransfer.cs
@@ -47,7 +47,7 @@ namespace Perrich.SepaWriter
             get { return SepaIban; }
             set
             {
-                if (!value.IsValid || value.UnknownBic)
+                if (!value.IsValid)
                     throw new SepaRuleException("Debtor IBAN data are invalid.");
                 SepaIban = value;
             }
@@ -154,7 +154,19 @@ namespace Perrich.SepaWriter
 			}
 
             var dbtrAcct = pmtInf.NewElement("DbtrAcct");
-            dbtrAcct.NewElement("Id").NewElement("IBAN", Debtor.Iban);
+            var dbtrAcctId = dbtrAcct.NewElement("Id");
+            if (!String.IsNullOrEmpty(Debtor.Iban))
+            {
+                dbtrAcctId.NewElement("IBAN", Debtor.Iban);
+            } 
+            else if (!String.IsNullOrEmpty(Debtor.Other))
+            {
+                dbtrAcctId.NewElement("Othr").NewElement("Id", Debtor.Other);
+            }
+            else
+            {
+                throw new Exception("Need either IBAN or Other>Id for DbtrAcct.");
+            }
             dbtrAcct.NewElement("Ccy", DebtorAccountCurrency);
 
             var finInstnId = pmtInf.NewElement("DbtrAgt").NewElement("FinInstnId");

--- a/SepaWriter/SepaCreditTransfer.cs
+++ b/SepaWriter/SepaCreditTransfer.cs
@@ -141,10 +141,11 @@ namespace Perrich.SepaWriter
 			}
 			
 			pmtInf.NewElement("ReqdExctnDt", StringUtils.FormatDate(RequestedExecutionDate));
-            pmtInf.NewElement("Dbtr").NewElement("Nm", Debtor.Name);
+            var dbtr = pmtInf.NewElement("Dbtr");
+            dbtr.NewElement("Nm", Debtor.Name);
             if (Debtor.Address != null)
             {
-                AddPostalAddressElements(pmtInf, "Dbtr", Debtor.Address);
+                XmlUtils.AddPostalAddressElements(dbtr, Debtor.Address);
             }
 			if (InitiatingPartyId != null) {
 				XmlUtils.GetFirstElement(pmtInf, "Dbtr").
@@ -156,10 +157,11 @@ namespace Perrich.SepaWriter
             dbtrAcct.NewElement("Id").NewElement("IBAN", Debtor.Iban);
             dbtrAcct.NewElement("Ccy", DebtorAccountCurrency);
 
-            pmtInf.NewElement("DbtrAgt").NewElement("FinInstnId").NewElement("BIC", Debtor.Bic);
+            var finInstnId = pmtInf.NewElement("DbtrAgt").NewElement("FinInstnId");
+            finInstnId.NewElement("BIC", Debtor.Bic);
             if (Debtor.AgentAddress != null)
             {
-                AddPostalAddressElements(pmtInf, "FinInstnId", Debtor.AgentAddress);
+                XmlUtils.AddPostalAddressElements(finInstnId, Debtor.AgentAddress);
             }
 
             if (IsInternational)
@@ -195,10 +197,12 @@ namespace Perrich.SepaWriter
                        .NewElement("InstdAmt", StringUtils.FormatAmount(transfer.Amount))
                        .SetAttribute("Ccy", transfer.Currency);
             XmlUtils.CreateBic(cdtTrfTxInf.NewElement("CdtrAgt"), transfer.Creditor);
-            cdtTrfTxInf.NewElement("Cdtr").NewElement("Nm", transfer.Creditor.Name);
+
+            var cdtr = cdtTrfTxInf.NewElement("Cdtr");
+            cdtr.NewElement("Nm", transfer.Creditor.Name);
             if (transfer.Creditor.Address != null)
             {
-                AddPostalAddressElements(pmtInf, "Cdtr", transfer.Creditor.Address);
+                XmlUtils.AddPostalAddressElements(cdtr, transfer.Creditor.Address);
             }
 
             cdtTrfTxInf.NewElement("CdtrAcct").NewElement("Id").NewElement("IBAN", transfer.Creditor.Iban);

--- a/SepaWriter/SepaDebitTransfer.cs
+++ b/SepaWriter/SepaDebitTransfer.cs
@@ -157,9 +157,9 @@ namespace Perrich.SepaWriter
             pmtInf.NewElement("ReqdColltnDt", StringUtils.FormatDate(RequestedExecutionDate));
             pmtInf.NewElement("Cdtr").NewElement("Nm", Creditor.Name);
 
-            var dbtrAcct = pmtInf.NewElement("CdtrAcct");
-            dbtrAcct.NewElement("Id").NewElement("IBAN", Creditor.Iban);
-            dbtrAcct.NewElement("Ccy", CreditorAccountCurrency);
+            var cdtrAcct = pmtInf.NewElement("CdtrAcct");
+            cdtrAcct.NewElement("Id").NewElement("IBAN", Creditor.Iban);
+            cdtrAcct.NewElement("Ccy", CreditorAccountCurrency);
 
             var finInstnId = pmtInf.NewElement("CdtrAgt").NewElement("FinInstnId");
             finInstnId.NewElement("BIC", Creditor.Bic);
@@ -198,7 +198,20 @@ namespace Perrich.SepaWriter
 
             XmlUtils.CreateBic(cdtTrfTxInf.NewElement("DbtrAgt"), transfer.Debtor);
             cdtTrfTxInf.NewElement("Dbtr").NewElement("Nm", transfer.Debtor.Name);
-            cdtTrfTxInf.NewElement("DbtrAcct").NewElement("Id").NewElement("IBAN", transfer.Debtor.Iban);
+
+            var dbtrAcctId = cdtTrfTxInf.NewElement("DbtrAcct");
+            if (!String.IsNullOrEmpty(transfer.Debtor.Iban))
+            {
+                dbtrAcctId.NewElement("IBAN", transfer.Debtor.Iban);
+            } 
+            else if (!String.IsNullOrEmpty(transfer.Debtor.Other))
+            {
+                dbtrAcctId.NewElement("Othr").NewElement("Id", transfer.Debtor.Other);
+            }
+            else
+            {
+                throw new Exception("Need either IBAN or Other>Id for DbtrAcct.");
+            }
 
             if (!string.IsNullOrEmpty(transfer.RemittanceInformation))
                 cdtTrfTxInf.NewElement("RmtInf").NewElement("Ustrd", transfer.RemittanceInformation);

--- a/SepaWriter/SepaDebitTransfer.cs
+++ b/SepaWriter/SepaDebitTransfer.cs
@@ -161,7 +161,12 @@ namespace Perrich.SepaWriter
             dbtrAcct.NewElement("Id").NewElement("IBAN", Creditor.Iban);
             dbtrAcct.NewElement("Ccy", CreditorAccountCurrency);
 
-            pmtInf.NewElement("CdtrAgt").NewElement("FinInstnId").NewElement("BIC", Creditor.Bic);
+            var finInstnId = pmtInf.NewElement("CdtrAgt").NewElement("FinInstnId");
+            finInstnId.NewElement("BIC", Creditor.Bic);
+            if (Creditor.AgentAddress != null)
+            {
+                XmlUtils.AddPostalAddressElements(finInstnId, Creditor.AgentAddress);
+            }
             pmtInf.NewElement("ChrgBr", "SLEV");
 
             var othr = pmtInf.NewElement("CdtrSchmeId").NewElement("Id")

--- a/SepaWriter/SepaIbanData.cs
+++ b/SepaWriter/SepaIbanData.cs
@@ -9,6 +9,7 @@ namespace Perrich.SepaWriter
     /// </summary>
     public class SepaIbanData : ICloneable
     {
+        private string other;
         private string bic;
         private string iban;
         private string name;
@@ -87,9 +88,24 @@ namespace Perrich.SepaWriter
             get { return iban; }
             set
             {
-                if (value == null || value.Length < 14 || value.Length > 34)
+                if (value != null && (value.Length < 14 || value.Length > 34))
                     throw new SepaRuleException(string.Format("Null or Invalid length of IBAN code \"{0}\", must contain between 14 and 34 characters.", value));
                 iban = SpaceRegex.Replace(value, string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Represents the Id only. SchmeNm and Issr are not presently accounted for
+        /// </summary>
+        public string Other
+        {
+            get { return other; }
+            
+            set
+            {
+                if (value != null && value.Length > 34)
+                    throw new SepaRuleException(string.Format("Invalid length of Othr > Id \"{0}\", must contain a maximum of 34 characters.", value));
+                other = SpaceRegex.Replace(value, string.Empty);
             }
         }
 
@@ -99,7 +115,7 @@ namespace Perrich.SepaWriter
         /// <returns></returns>
         public bool IsValid
         {
-            get { return (!string.IsNullOrEmpty(bic) || withoutBic) && !string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(iban); }
+            get { return (!string.IsNullOrEmpty(bic) || withoutBic) && !string.IsNullOrEmpty(name) && (!string.IsNullOrEmpty(iban) || !string.IsNullOrEmpty(other)); }
         }
 
         /// <summary>

--- a/SepaWriter/SepaTransfer.cs
+++ b/SepaWriter/SepaTransfer.cs
@@ -152,32 +152,6 @@ namespace Perrich.SepaWriter
                 throw new SepaRuleException("End to End Id '" + endToEndId + "' must be unique in a transfer.");
             }
         }
-        
-        protected void AddPostalAddressElements(XmlElement pmtInf, string existingElementKey, SepaPostalAddress address)
-        {
-            var pstlAdr = XmlUtils.GetFirstElement(pmtInf, existingElementKey).NewElement("PstlAdr");
-            if (address.AddressType.HasValue)
-                pstlAdr.NewElement("AdrTp", address.AddressType.ToString());
-            if (!String.IsNullOrEmpty(address.Dept))
-                pstlAdr.NewElement("Dept", address.Dept);
-            if (!String.IsNullOrEmpty(address.SubDept))
-                pstlAdr.NewElement("SubDept", address.SubDept);
-            if (!String.IsNullOrEmpty(address.StrtNm))
-                pstlAdr.NewElement("StrtNm", address.StrtNm);
-            if (!String.IsNullOrEmpty(address.BldgNb))
-                pstlAdr.NewElement("BldgNb", address.BldgNb);
-            if (!String.IsNullOrEmpty(address.PstCd))
-                pstlAdr.NewElement("PstCd", address.PstCd);
-            if (!String.IsNullOrEmpty(address.TwnNm))
-                pstlAdr.NewElement("TwnNm", address.TwnNm);
-            if (!String.IsNullOrEmpty(address.CtrySubDvsn))
-                pstlAdr.NewElement("CtrySubDvsn", address.CtrySubDvsn);
-            if (!String.IsNullOrEmpty(address.Ctry))
-                pstlAdr.NewElement("Ctry", address.Ctry);
-            if (address.AdrLine != null)
-                foreach (var line in address.AdrLine)
-                    pstlAdr.NewElement("AdrLine", line);
-        }
 
         /// <summary>
         ///     Is Mandatory data are set ? In other case a SepaRuleException will be thrown

--- a/SepaWriter/Utils/XmlUtils.cs
+++ b/SepaWriter/Utils/XmlUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System;
+using System.Xml;
 
 namespace Perrich.SepaWriter.Utils
 {
@@ -31,8 +32,48 @@ namespace Perrich.SepaWriter.Utils
             }
             else
             {
-                element.NewElement("FinInstnId").NewElement("BIC", iban.Bic);
+                var finInstnId = element.NewElement("FinInstnId");
+                finInstnId.NewElement("BIC", iban.Bic);
+
+                if (iban.AgentAddress != null)
+                {
+                    AddPostalAddressElements(finInstnId, iban.AgentAddress);
+                }
             }
+
+        }
+
+        /// <summary>
+        /// Create an XmlElement for the provided address and add to the parent XmlElement
+        /// according to the provided key.
+        /// </summary>
+        /// <param name="parent"></param>
+        /// <param name="existingElementKey"></param>
+        /// <param name="address"></param>
+        public static void AddPostalAddressElements(XmlElement parent, SepaPostalAddress address)
+        {
+            var pstlAdr = parent.NewElement("PstlAdr");
+            if (address.AddressType.HasValue)
+                pstlAdr.NewElement("AdrTp", address.AddressType.ToString());
+            if (!String.IsNullOrEmpty(address.Dept))
+                pstlAdr.NewElement("Dept", address.Dept);
+            if (!String.IsNullOrEmpty(address.SubDept))
+                pstlAdr.NewElement("SubDept", address.SubDept);
+            if (!String.IsNullOrEmpty(address.StrtNm))
+                pstlAdr.NewElement("StrtNm", address.StrtNm);
+            if (!String.IsNullOrEmpty(address.BldgNb))
+                pstlAdr.NewElement("BldgNb", address.BldgNb);
+            if (!String.IsNullOrEmpty(address.PstCd))
+                pstlAdr.NewElement("PstCd", address.PstCd);
+            if (!String.IsNullOrEmpty(address.TwnNm))
+                pstlAdr.NewElement("TwnNm", address.TwnNm);
+            if (!String.IsNullOrEmpty(address.CtrySubDvsn))
+                pstlAdr.NewElement("CtrySubDvsn", address.CtrySubDvsn);
+            if (!String.IsNullOrEmpty(address.Ctry))
+                pstlAdr.NewElement("Ctry", address.Ctry);
+            if (address.AdrLine != null)
+                foreach (var line in address.AdrLine)
+                    pstlAdr.NewElement("AdrLine", line);
         }
     }
 }


### PR DESCRIPTION
…ed references to use the new method. Method also takes the parent directly now, rather than searching, as this seems to cause an issue with the scope and sometimes the wrong node is returned.

The main reason for doing this was to allow the address node to be added on the "FinInstnId" element created by the "CreateBic" method (which is static).