### PR TITLE
Declare support for netcoreapp3.1

### DIFF
--- a/SepaWriter.Test/SepaWriter.Test.csproj
+++ b/SepaWriter.Test/SepaWriter.Test.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
     <AssemblyName>Perrich.SepaWriter.Test</AssemblyName>
 
     <RootNamespace>Perrich.SepaWriter.Test</RootNamespace>
+
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/SepaWriter/SepaWriter.csproj
+++ b/SepaWriter/SepaWriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Declares support for netcoreapp3.1 and avoids a build warning in such projects.

I found no issues using the library using this target.